### PR TITLE
Treat lone dash ("-") output filename  as stdout

### DIFF
--- a/src/capture.h
+++ b/src/capture.h
@@ -18,7 +18,7 @@
 
 int nsntrace_capture_start(const char *iface,
                            const char *filter,
-                           const char *outfile);
+                           FILE *fp);
 
 void nsntrace_capture_stop();
 


### PR DESCRIPTION
In this case we only output pcap data on stdout and redirect all other
output to stderr.

Closes #24