### PR TITLE
Handle DNS when nameserver is loopback address

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ address is a loopback address (like 127.0.0.53) where that application
 listens for incoming DNS queries.
 
 This will not work for us in this network namespace environment, since
-we have our own namespaced loopback device.
+we have our own namespaced loopback device. To work around this one can use the
+`--use-public-dns` option to override resolv.conf in the namespace. Then nsntrace
+will use nameservers from Quad9 (9.9.9.9), Cloudflare (1.1.1.1), Google (8.8.8.8) and
+OpenDNS (208.67.222.222) to perform DNS queries.
 
 ## usage
     $ nsntrace
@@ -43,10 +46,12 @@ we have our own namespaced loopback device.
     Perform network trace of a single process by using network namespaces.
 
     Options:
-    -o file     send trace output to file (default nsntrace.pcap), use '-' for stdout
-    -d device   the network device to trace
-    -f filter   an optional capture filter
-    -u username run program as username/uid
+    -o file          	send trace output to file (default nsntrace.pcap)
+    -d device        	the network device to trace
+    -f filter        	an optional capture filter
+    -u username      	run program as username/uid
+    --use-public-dns	override resolv.conf to use public nameservers from
+                    	Quad9, Cloudflare, Google and OpenDNS
 
 ## example
 ```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ ip address will be the NAT one of the virtual device.
 Another limitation is, that since we are using iptables and since
 we are tracing raw sockets. This application needs to be run as root.
 
+On many systems today the nameserver functionality is handled by an
+application such as systemd-resolved or dnsmasq and the nameserver
+address is a loopback address (like 127.0.0.53) where that application
+listens for incoming DNS queries.
+
+This will not work for us in this network namespace environment, since
+we have our own namespaced loopback device.
+
 ## usage
     $ nsntrace
     usage: nsntrace [options] program [arguments]

--- a/man/nsntrace.xml
+++ b/man/nsntrace.xml
@@ -77,6 +77,16 @@
         </para></listitem>
       </varlistentry>
 
+
+      <varlistentry>
+        <term><option>--use-public-dns</option></term>
+        <listitem><para>
+          Override resolv.conf in namespace to use public nameservers from
+          Quad9 (9.9.9.9), Cloudflare (1.1.1.1), Google (8.8.8.8) and
+          OpenDNS (208.67.222.222).
+        </para></listitem>
+      </varlistentry>
+
       <varlistentry>
         <term><option>--outfile <replaceable>file</replaceable></option></term>
         <term><option>-o <replaceable>file</replaceable></option></term>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,4 +16,4 @@ sources =			\
 nsntrace_SOURCES = $(headers) $(sources)
 nsntrace_CPPFLAGS = $(LIBNL_CFLAGS) $(warnings)
 nsntrace_LDFLAGS = -pthread
-nsntrace_LDADD = $(LIBNL_LIBS)
+nsntrace_LDADD = $(LIBNL_LIBS) -lresolv

--- a/src/net.h
+++ b/src/net.h
@@ -16,12 +16,14 @@
 #ifndef _NSNTRACE_NET_H_
 #define _NSNTRACE_NET_H
 
+#define NSNTRACE_RUN_DIR "/run/nsntrace"
+
 int nsntrace_net_init(pid_t ns_pid,
                       const char *device);
 
 int nsntrace_net_deinit(const char *device);
 
-int nsntrace_net_ns_init();
+int nsntrace_net_ns_init(int use_public_dns);
 
 int nsntrace_net_ip_forward_enabled();
 

--- a/tests/check_cleanup.sh
+++ b/tests/check_cleanup.sh
@@ -20,6 +20,11 @@ check_cleanup() {
         exit 1
     }
 
+    ls /run/nsntrace > /dev/null 2>&1 && {
+        echo "run-time files not cleaned up after signal $signal"
+        exit 1
+    }
+
     rm -rf *.pcap
 }
 


### PR DESCRIPTION
On many systems today the nameserver functionality is handled by an
application such as systemd-resolved or dnsmasq and the nameserver
address is a loopback address (like 127.0.0.53) where that application
listens for incoming DNS queries.

This will not work for us in this network namespace environment.
For those cases this PR propose one can use a new `--use-public-dns` 
command line option. That will override the system resolv.conf.
In order to have our own nameservers for our network namespace we will
bind mount our own resolv.conf file over the system-wide one at
/etc/resolv.conf.

But we do not want to affect others outside this namespace. So we enter
a mount namespace (CLONE_NEWNS) before we do the bind mount. This,
however, is not enough. Before the bind mount we need to remount the
root partition with the MS_SLAVE and MS_REC flags to make sure our
changes are not propagated to the outside mount namespace. As some
systems have that as the default behavior.