### PR TITLE
Enable running multiple instances of nsntrace

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -293,19 +293,15 @@ static void
 _nsntrace_net_create_resolv_conf()
 {
 	int fd;
+	char resolv_path[PATH_MAX] = { 0, };
 	const char *resolv = "nameserver 9.9.9.9\n"         /* Quad9 */
 			     "nameserver 1.1.1.1\n"         /* Cloudflare */
 			     "nameserver 8.8.8.8\n"         /* Google */
 			     "nameserver 208.67.222.222\n"; /* OpenDNS */
 
-	if (mkdir(NSNTRACE_RUN_DIR, 0644) < 0) {
-		if (errno != EEXIST) {
-			perror("mkdir");
-			return;
-		}
-	}
 
-	char resolv_path[] = NSNTRACE_RUN_DIR "/resolv.confXXXXXX";
+	snprintf(resolv_path, PATH_MAX, "%s/%d/resolv.confXXXXXX",
+		 NSNTRACE_RUN_DIR, getppid());
 	if ((fd = mkstemp(resolv_path)) < 0) {
 		perror("mkstemp");
 		return;

--- a/src/net.h
+++ b/src/net.h
@@ -16,19 +16,34 @@
 #ifndef _NSNTRACE_NET_H_
 #define _NSNTRACE_NET_H
 
+#include <linux/if.h>
+
+#define IP_ADDR_LEN 16 // 4 sets of 3 numbers each separater by a dot + '\0'
 #define NSNTRACE_RUN_DIR "/run/nsntrace"
 
+struct nsntrace_if_info {
+    char ns_if[IFNAMSIZ];
+    char gw_if[IFNAMSIZ];
+    char ns_ip[16];
+    char gw_ip[16];
+    char ns_ip_range[19];
+    char gw_ip_range[19];
+};
+
 int nsntrace_net_init(pid_t ns_pid,
-                      const char *device);
+                      const char *device,
+                      struct nsntrace_if_info *info);
 
-int nsntrace_net_deinit(const char *device);
+int nsntrace_net_deinit(pid_t ns_pid,
+                        const char *device,
+                        struct nsntrace_if_info *info);
 
-int nsntrace_net_ns_init(int use_public_dns);
+int nsntrace_net_ns_init(int use_public_dns,
+                         struct nsntrace_if_info *info);
 
 int nsntrace_net_ip_forward_enabled();
 
-const char *nsntrace_net_get_capture_ip();
-
-const char *nsntrace_net_get_capture_interface();
+int nsntrace_net_get_if_info(pid_t pid,
+                             struct nsntrace_if_info *info);
 
 #endif

--- a/tests/check_cleanup.sh
+++ b/tests/check_cleanup.sh
@@ -7,6 +7,7 @@ ip="172.16.42.254"
 if=nsntrace
 
 check_cleanup() {
+    local pid="$1"
     # sleep to allow for cleanup after signal
     sleep 1
 
@@ -20,7 +21,7 @@ check_cleanup() {
         exit 1
     }
 
-    ls /run/nsntrace > /dev/null 2>&1 && {
+    ls "/run/nsntrace/$1" > /dev/null 2>&1 && {
         echo "run-time files not cleaned up after signal $signal"
         exit 1
     }
@@ -36,11 +37,14 @@ start_and_kill() {
     pid=$(pidof nsntrace)
     sudo kill -$signal $pid
 
-    check_cleanup
+    check_cleanup "$pid"
  }
 
 for signal in $signals; do
     start_and_kill $signal
 done
+
+sudo ../src/nsntrace ./test_program_dummy_ends.sh
+check_cleanup "$!"
 
 exit 0

--- a/tests/check_multiple.sh
+++ b/tests/check_multiple.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+num_packets=10
+
+launch_nsntrace()
+{
+    local id="$1"
+    local filter="icmp[icmptype]==icmp-echo"
+
+    sudo ../src/nsntrace  -f "$filter" --use-public-dns -o "$id.pcap" ping -c $num_packets google.com > /dev/null 2>&1 &
+    sleep 1.0e-3
+}
+
+for i in `seq 5`; do
+    launch_nsntrace "$i"
+done
+
+sleep 20
+
+for i in `seq 5`; do
+    captured=$(tshark -r "$i.pcap" | wc -l)
+    [ "$captured" = "$num_packets" ] || {
+        echo "failed to capture all packets"
+        exit 1
+    }
+done
+
+rm -f *.pcap
+exit 0

--- a/tests/test_program_dummy_ends.sh
+++ b/tests/test_program_dummy_ends.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+sleep 5
+

--- a/tests/udp_send.c
+++ b/tests/udp_send.c
@@ -11,14 +11,18 @@
 int main(int argc, char **argv)
 {
 	struct sockaddr_in addr = { 0 };
-	int port, num, s;
+	int port, num, s, interval = 0;
 
-	if (argc != 3) {
-		fprintf(stderr, "usage: udp_send port num_packets\n");
+	if (argc < 3) {
+		fprintf(stderr, "usage: udp_send port num_packets [interval]\n");
 		exit(EXIT_FAILURE);
 	}
 	port = atoi(argv[1]);
 	num = atoi(argv[2]);
+
+	if (argc > 3) {
+		interval = atoi(argv[3]);
+	}
 
 	if ((s = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
 		fprintf(stderr, "failed to create socket\n");
@@ -39,6 +43,8 @@ int main(int argc, char **argv)
 			fprintf(stderr, "failed to send message\n");
 			exit(EXIT_FAILURE);
 		}
+
+		sleep(interval);
 	}
 
 	return 0;


### PR DESCRIPTION
This PR includes commit to make sure the run-time data can be shared when multiple instances are running. It also takes care to allocate names and addresses for network interfaces in a way that avoids collisions.

Closes #21